### PR TITLE
Subdomain matching not supported

### DIFF
--- a/src/ElliotJReed/DisposableEmail/Email.php
+++ b/src/ElliotJReed/DisposableEmail/Email.php
@@ -58,9 +58,19 @@ class Email
      */
     private function inDisposableEmailList(string $email): bool
     {
-        $emailDomain = $this->getEmailDomainFromFullEmailAddress($email);
+        $emailDomain = \strtolower($this->getEmailDomainFromFullEmailAddress($email));
+        $domainParts = \explode('.', $emailDomain);
+        $domains = $this->getDomainsFromFile();
 
-        return \in_array(\strtolower($emailDomain), $this->getDomainsFromFile(), true);
+        // Check domain and all parent domains (skip checking TLD alone)
+        for ($i = 0, $count = \count($domainParts); $i < $count - 1; $i++) {
+            $checkDomain = \implode('.', \array_slice($domainParts, $i));
+            if (\in_array($checkDomain, $domains, true)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Currently isDisposable() only checks for an exact domain match. If example.com is in the blocklist, emails like user@sub.example.com will pass through undetected. This is an issue with a lot of [new disposable emails](https://github.com/wesbos/burner-email-providers/issues/527#issue-3816715937).

I've opened a PR to fix this by checking the domain and all parent domains (e.g. sub.example.com → example.com).

One note: the current implementation uses in_array() which is O(n) per lookup. For single calls this is fine, but for long-running scripts or batch processing multiple emails, it would be more efficient to use array_flip() on the domain list and check with isset() instead - turning each lookup into O(1). Do you want to handle this / offer it as an option?